### PR TITLE
Fix: Don't run CI on pushes

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,8 +1,6 @@
 name: build & test
 
 on:
-  push:
-    branches: [ "prod" ]
   pull_request:
     branches: [ "prod" ]
 


### PR DESCRIPTION
Direct push is not allowed, so all PRs will have to pass CI. 

Pushes will have a CD workflow