### PR TITLE
CD: Provision First, then deploy

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -80,16 +80,16 @@ jobs:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Enable Resource Group Deployments
         run: azd config set alpha.resourceGroupDeployments on
-      # - name: Provision Infrastructure
-      #   run: azd provision --no-prompt --debug
-      #   env:
-      #     AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
-      #     AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
-      #     AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      #     AZURE_TAGS: ${{ secrets.AZURE_TAGS }}
+      - name: Provision Infrastructure
+        run: azd provision --no-prompt --debug
+        env:
+          AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
+          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TAGS: ${{ secrets.AZURE_TAGS }}
 
       - name: Deploy Application
-        run: azd up
+        run: azd deploy --no-prompt --debug
         env:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}


### PR DESCRIPTION
Sometimes there may be errors with the service principal's role assignments on the azure tenant. 

For this reason, running `azd up` can take much longer for the workflow to run only for it to fail on the provision step.

We check if we have the permissions first, then package, then deploy.

`azd up` will package first then attempt to deploy assuming you've sorted the permissions first.