### PR TITLE
Security: Increase Azure AI Search API Permissions

### DIFF
--- a/app/SharedWebComponents/Pages/Docs.razor.cs
+++ b/app/SharedWebComponents/Pages/Docs.razor.cs
@@ -158,7 +158,7 @@ public sealed partial class Docs : IDisposable
         HttpRequestMessage request = new();
         request.RequestUri = new Uri("https://gptkb-r6lomx22dqabk.search.windows.net/indexes/gptkbindex/docs?api-version=2024-05-01-preview&facet=category,count:1000");
         request.Method = HttpMethod.Get;
-        request.Headers.Add("api-key", "ARNSvbnPWMRETL0rcPw3VmB0T1Fhsa4fnCFSkTBSKwAzSeAMgWiZ");
+        request.Headers.Add("api-key", "PQy5AIQF6dO3Ng2Pi15mgFIHsv5A3cc4XQOOoDIqIwAzSeA6WCrs");
         //request.Headers.Add("Access-Control-Allow-Origin", "*");
 
         //request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/app/SharedWebComponents/Shared/MainLayout.razor.cs
+++ b/app/SharedWebComponents/Shared/MainLayout.razor.cs
@@ -99,7 +99,7 @@ public sealed partial class MainLayout
         request.Method = HttpMethod.Get;
       
       // FIXME : Doesn't work locally
-        request.Headers.Add("api-key", "ARNSvbnPWMRETL0rcPw3VmB0T1Fhsa4fnCFSkTBSKwAzSeAMgWiZ");
+        request.Headers.Add("api-key", "PQy5AIQF6dO3Ng2Pi15mgFIHsv5A3cc4XQOOoDIqIwAzSeA6WCrs");
       
  
         //request.Headers.Add("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Addresses #64 , Document Upload procedure also includes AI Search Index WRITE. This permission was never granted with original api-key because it was only for query, this PR includes admin that allows this. 

Should resolve issue.