### PR TITLE
Feature: Single Sign In / Single Sign Out button + User Info 

### DIFF
--- a/app/SharedWebComponents/Shared/MainLayout.razor
+++ b/app/SharedWebComponents/Shared/MainLayout.razor
@@ -1,5 +1,7 @@
 ﻿@inherits             LayoutComponentBase
 @inject NavigationManager NavManager
+@inject IAccessTokenProvider AccessTokenProvider
+@inject SignOutSessionStateManager SignOutManager
 <MudThemeProvider @bind-IsDarkMode="@_isDarkTheme" Theme="_theme" />
 <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.Small"
                    CloseButton="true"
@@ -41,6 +43,7 @@
                 
             }
             <MudSpacer />
+           
             @if (SettingsDisabled is false)
                     {
             <MudIconButton Icon="@Icons.Material.Filled.Settings" style="@($"{(_isDarkTheme ? Colors.Brown.Default : Colors.Cyan.Default)}")" Size="Size.Large"
@@ -51,7 +54,22 @@
                                 ToggledSize="Size.Large"
                                  Title="Switch to Dark theme" Icon=@Icons.Material.Filled.DarkMode Color="@Color.Inherit"
                                 ToggledTitle="Switch to Light theme" ToggledIcon=@Icons.Material.Filled.WbSunny ToggledColor=@Color.Warning />
-            <LogoutDisplay />
+            <AuthorizeView>
+                <Authorized>
+                    <MudMenu Color="@Color.Inherit" Label="@context.User.Identity.Name">
+                        <MudMenuItem IconSize="Size.Small" OnClick="@OnUserInfoClicked" IconColor="Color.Primary" Icon="@Icons.Material.Rounded.Person">View Info</MudMenuItem>
+                        <MudMenuItem IconSize="Size.Small" OnClick="@OnLogOutClicked" IconColor="Color.Primary" Icon="@Icons.Material.Rounded.SensorDoor">Log Out</MudMenuItem>
+                    </MudMenu>
+                </Authorized>
+                <NotAuthorized>
+                    <MudButton Href="authentication/login"
+                               Variant="Variant.Text"
+                               EndIcon="@Icons.Custom.Brands.Microsoft"
+                               Color="Color.Inherit">
+                        Log In
+                    </MudButton>
+                </NotAuthorized>
+            </AuthorizeView>
         </MudAppBar>
         <MudDrawer @bind-Open="_drawerOpen" Elevation="5" id="drawer">
             <MudDrawerHeader>
@@ -75,3 +93,19 @@
         </MudMainContent>
     </MudLayout>
 </MudRTLProvider>
+
+@code {
+    private void OnUserInfoClicked()
+    {
+        NavManager.NavigateTo("user");
+    }
+    private async void OnLogOutClicked()
+    {
+        await SignOutManager.SetSignOutState();
+        NavManager.NavigateTo("authentication/logout");
+    }
+    private void OnLogInClicked()
+    {
+        NavManager.NavigateTo("authentication/login");
+    }
+}

--- a/app/SharedWebComponents/Shared/NavMenu.razor
+++ b/app/SharedWebComponents/Shared/NavMenu.razor
@@ -16,9 +16,6 @@
                 Icon="@Icons.Material.Filled.FolderSpecial">
         Documents
     </MudNavLink>
-    <MudNavLink Href="authentication/login">
-        Log In
-    </MudNavLink>
     <MudNavGroup Expanded Title="Chats" Icon="@Icons.Material.Filled.QuestionAnswer">
         <MudNavLink OnClick="AddNewChat"
                     Icon="@Icons.Material.Rounded.Add">


### PR DESCRIPTION
After SSO auto sign in was enabled with #92 , this PR includes a new component available in the NavBar that shows username. 

You can view all collected information from graphs api .

Also, when an authenticated user is active, a button that allows for secure single sign out will clear the token from browser and sign out from azure ad.

Sign In button was also added for unauthenticated users that has same trigger as any authenticated page to SSO with AzureAD.